### PR TITLE
Bump var-dumper minimum version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/http-kernel": "^3.4|^4.0|^5.0",
         "symfony/polyfill-php80": "^1.16",
         "symfony/twig-bridge": "^3.4|^4.0|^5.0",
-        "symfony/var-dumper": "^4.1.1|^5.0"
+        "symfony/var-dumper": "^4.4|^5.0"
     },
     "require-dev": {
         "symfony/config": "^4.2|^5.0",


### PR DESCRIPTION
*  debug-bundle register the ContextualizedDumper service which is not
   implemented before var-dumper 4.4